### PR TITLE
Issue #25: Rename preprocess_html to preprocess_page.

### DIFF
--- a/template.php
+++ b/template.php
@@ -17,9 +17,9 @@ require_once dirname(__FILE__) . '/includes/admin.inc';
 require_once dirname(__FILE__) . '/includes/contrib.inc';
 
 /**
- * Implements template_preprocess_html().
+ * Implements template_preprocess_page().
  */
-function radix_preprocess_html(&$variables) {
+function radix_preprocess_page(&$variables) {
   global $base_url;
 
   // Add Bootstrap JS from CDN if bootstrap library is not installed.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/radix/issues/25
